### PR TITLE
Fix/color scheme toggle hydration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,13 @@ Pre-existing; worth fixing if you are already in the file.
 - `src/utils/markdown.ts` hardcodes `bg-stone-100 dark:bg-stone-900` for code blocks instead of theme variables.
 - `prose-editorial` is applied in `posts/[id]/page.tsx` but defined nowhere.
 - `useGazeTracking` mirrors state into refs with two `useEffect`s; the throttle also mixes `performance.now()` bookkeeping into the same hook.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/src/components/ColorSchemeToggle.tsx
+++ b/src/components/ColorSchemeToggle.tsx
@@ -10,10 +10,6 @@ const ColorSchemeToggle = ({ className }: { className?: string }) => {
   const controls = useAnimation();
   const { resolvedTheme, setTheme } = useTheme();
 
-  if (!resolvedTheme) {
-    return <div className={cn("w-8 h-8", className)} />;
-  }
-
   return (
     <button
       title="Toggle color mode"
@@ -49,11 +45,13 @@ const ColorSchemeToggle = ({ className }: { className?: string }) => {
           transition: { duration: 0.5 },
         }}
       >
-        {resolvedTheme === "light" ? (
-          <Sun className="w-4 h-4" />
-        ) : (
-          <Moon className="w-4 h-4" />
-        )}
+        {/* Both icons are always rendered and CSS picks one, so the markup is
+            identical on the server and on the client. Branching on
+            `resolvedTheme` here instead would hydrate-mismatch: it is
+            undefined during SSR but already resolved on the first client
+            render. */}
+        <Sun className="w-4 h-4 dark:hidden" />
+        <Moon className="hidden w-4 h-4 dark:block" />
       </motion.div>
     </button>
   );


### PR DESCRIPTION
Fixes the React #418 hydration mismatch that fired on every page load.

## The bug

`ColorSchemeToggle` bailed to a placeholder when `resolvedTheme` was falsy, then branched on it again to choose an icon. `resolvedTheme` is undefined while rendering on the server but already resolved on the first client render, so the two trees never agreed:

```
<ColorSchemeToggle>
+   <button title="Toggle color mode" ...>   // client
-   <div className="w-8 h-8">                // server
```

React discarded the server-rendered subtree and regenerated it on the client.

## The fix

Render one tree and let CSS choose the icon, which is how the rest of the site already handles theming. Both icons are always present and the `dark` variant (`[data-color-scheme="dark"]`, set by next-themes before paint) hides one. Nothing renders conditionally on theme state, so server and client markup are identical by construction — no `mounted` flag and no extra effect.

Side benefits: the placeholder's layout shift is gone (the button occupies its 8x8 slot from first paint), and with JS disabled the icon still matches the CSS-default light theme.

`resolvedTheme` is still read for the click handler, which only runs after mount.

## Verification

Checked in a real browser against both dev and production builds:

- console is clean where it previously showed #418 — the production build now logs only the two `/_vercel/*` 404s expected off-platform
- clicking flips `data-color-scheme`, persists to `localStorage` and swaps the icon
- a full page load holding stored `light` against `defaultTheme="dark"` — the likeliest mismatch — hydrates without error
- `tsc --noEmit`, `eslint`, `prettier --check .` and the production build all pass

The unminified dev error also flagged a second warning about a `<script>` tag inside a React component (next-themes' pre-paint script); that no longer appears either.

## Second commit

`next dev` appends a delimited `<!-- BEGIN:nextjs-agent-rules -->` block to `CLAUDE.md` on every run — see `node_modules/next/dist/server/lib/generate-agent-files.js`. Leaving it uncommitted means the tree is dirty again the moment anyone starts the dev server, so it is committed once here. Set `agentRules: false` in `next.config.ts` to disable the generator instead.
